### PR TITLE
Healthcheck and Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 RUN apt-get update
-RUN apt-get -y install git libgomp1
-RUN pip install --upgrade pip setuptools
+RUN apt-get -y install git libgomp1 wget
+RUN pip install --upgrade --user pip setuptools
 
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -66,8 +66,15 @@ In order to test the built docker image run this command in project's root folde
 LOCAL_REPO="local-bind" ./cicd/test.sh
 ```
 
+You can also add a healthcheck for docker compose
+```docker
+    healthcheck:
+      test: wget --no-verbose --tries=3 --spider http://localhost:8080/.well-known/ready || exit 1
+```
+
 🔗 Useful Resources
 --------------------
 
 - [Meta AI ImageBind annoucement article](https://ai.facebook.com/blog/imagebind-six-modalities-binding-ai/)
 - [ImageBind github project](https://github.com/facebookresearch/ImageBind)
+- [Multi2Vec Bind JS Demo App](https://github.com/weaviate-tutorials/multi2vec-bind-js)

--- a/app.py
+++ b/app.py
@@ -38,6 +38,8 @@ app = FastAPI(lifespan=lifespan)
 
 @app.get("/.well-known/live", response_class=Response)
 @app.get("/.well-known/ready", response_class=Response)
+@app.head("/.well-known/live", response_class=Response)
+@app.head("/.well-known/ready", response_class=Response)
 async def live_and_ready(response: Response):
   response.status_code = status.HTTP_204_NO_CONTENT
 


### PR DESCRIPTION
Add necessary bits to perform healthcheck (wget to built image, HEAD methods for .well_known endpoints) 
adds `--user` to pip install as it was not building the docker image because of it.

This will help projects to have a better "docker compose up" experience by leveraging depends_on with service_healthy conditions. 